### PR TITLE
Added several wrapper functions and added controls for deallocation in wrapper structs 

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,26 +1,169 @@
-use crate::{error::Error, tensor::Tensor};
+use crate::{engine::Engine, error::Error, model::Model, tensor::Tensor};
 use deepviewrt_sys as ffi;
+use std::{cell::Cell, ffi::CString, ptr};
 
-pub struct NNContext {
+pub struct Context {
+    owned: bool,
     ptr: *mut ffi::NNContext,
+    engine: Cell<Option<Engine>>,
+    model_data: Option<Vec<u8>>,
+    model: Cell<Option<Model>>,
+    //	tensors: Cell
+    //	tensor_ref: Vec<(i32, Tensor)>
 }
 
-impl NNContext {
-    pub unsafe fn from_ptr(ptr: *mut ffi::NNContext) -> Result<NNContext, Error> {
+impl Context {
+    pub fn sizeof() -> usize {
+        return unsafe { ffi::nn_context_sizeof() };
+    }
+
+    pub fn new(engine: Engine, memory_size: usize, cache_size: usize) -> Result<Context, Error> {
+        let ret = unsafe {
+            ffi::nn_context_init(
+                engine.to_ptr_mut(),
+                memory_size,
+                ptr::null_mut(),
+                cache_size,
+                ptr::null_mut(),
+            )
+        };
+        if ret.is_null() {
+            return Err(Error::WrapperError(String::from(
+                "nn_context_init returned null",
+            )));
+        }
+        Ok(Context {
+            owned: true,
+            ptr: ret,
+            engine: Cell::new(Some(engine)),
+            model_data: None,
+            model: Cell::new(None),
+        })
+    }
+
+    /*
+    pub fn cache(&self) -> Option<Tensor> {
+
+    }
+
+    pub fn mempool(&self) -> Option<Tensor> {
+
+    }
+    */
+
+    pub fn engine(&self) -> Option<&Engine> {
+        let engine_ptr = self.engine.as_ptr();
+        if !engine_ptr.is_null() {
+            let engine_ref = unsafe { &*engine_ptr };
+            if engine_ref.is_some() {
+                return engine_ref.as_ref();
+            }
+        }
+
+        let ret = unsafe { ffi::nn_context_engine(self.ptr) };
+        if ret.is_null() {
+            return None;
+        }
+        let engine = Engine::wrap(ret).unwrap();
+        self.engine.set(Some(engine));
+        return unsafe { (&*self.engine.as_ptr()).as_ref() };
+    }
+
+    pub fn model(&self) -> Option<&Model> {
+        if !self.model.as_ptr().is_null() {
+            let model_ref = unsafe { &*self.model.as_ptr() };
+            if model_ref.is_some() {
+                return model_ref.as_ref();
+            }
+        }
+
+        let ret = unsafe { ffi::nn_context_model(self.ptr) };
+        if ret.is_null() {
+            return None;
+        }
+        let model = match unsafe { Model::try_from_ptr(ret) } {
+            Ok(model) => Some(model),
+            Err(e) => {
+                eprintln!("{}", e);
+                None
+            }
+        };
+        self.model.set(model);
+
+        let model_ref = unsafe { &*self.model.as_ptr() };
+        if model_ref.is_some() {
+            return model_ref.as_ref();
+        }
+        None
+    }
+
+    pub fn load_model(&mut self, data: Vec<u8>) -> Result<(), Error> {
+        self.unload_model();
+        //Insert and get the mode_data reference
+        let model_data_ref = self.model_data.insert(data);
+        let ret = unsafe {
+            ffi::nn_context_model_load(
+                self.ptr as *mut ffi::NNContext,
+                model_data_ref.len(),
+                model_data_ref.as_ptr() as *const std::ffi::c_void,
+            )
+        };
+        if ret != ffi::NNError_NN_SUCCESS {
+            return Err(Error::from(ret));
+        }
+        return Ok(());
+    }
+
+    pub fn unload_model(&mut self) {
+        unsafe { ffi::nn_context_model_unload(self.ptr) };
+        self.model_data = None;
+        self.model.set(None);
+    }
+
+    pub fn run_model(&self) {}
+
+    pub fn tensor(&self, name: &str) -> Option<Tensor> {
+        let cname = match CString::new(name) {
+            Ok(cname) => cname,
+            Err(_) => return None,
+        };
+
+        let ret = unsafe { ffi::nn_context_tensor(self.ptr, cname.into_raw()) };
+        if ret.is_null() {
+            return None;
+        }
+        let tensor = unsafe { Tensor::from_ptr(ret, false).unwrap() };
+        return Some(tensor);
+    }
+
+    pub fn tensor_index(&self, index: usize) -> Option<Tensor> {
+        let ret = unsafe { ffi::nn_context_tensor_index(self.ptr, index) };
+        if ret.is_null() {
+            return None;
+        }
+        let tensor = unsafe { Tensor::from_ptr(ret, false).unwrap() };
+        return Some(tensor);
+    }
+
+    pub unsafe fn from_ptr(ptr: *mut ffi::NNContext) -> Result<Self, Error> {
         if ptr.is_null() {
             return Err(Error::WrapperError(String::from("ptr is null")));
         }
 
-        return Ok(NNContext { ptr });
+        return Ok(Self {
+            owned: false,
+            ptr,
+            engine: Cell::new(None),
+            model_data: None,
+            model: Cell::new(None),
+        });
     }
+}
 
-    pub fn tensor_index(&self, index: usize) -> Result<Tensor, Error> {
-        let ret = unsafe { ffi::nn_context_tensor_index(self.ptr, index) };
-        if ret.is_null() {
-            return Err(Error::WrapperError(String::from("tensor is null")));
+impl Drop for Context {
+    fn drop(&mut self) {
+        if self.owned {
+            unsafe { ffi::nn_context_release(self.ptr) };
         }
-
-        let tensor = unsafe { Tensor::from_ptr(ret, false).unwrap() };
-        return Ok(tensor);
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,12 +1,13 @@
 use crate::error::Error;
 use deepviewrt_sys as ffi;
+use std::ffi::{CStr, CString};
 
 pub struct Model {
     ptr: *const ffi::NNModel,
 }
 
 impl Model {
-    pub fn try_from_ptr(ptr: *const ffi::NNModel) -> Result<Self, Error> {
+    pub unsafe fn try_from_ptr(ptr: *const ffi::NNModel) -> Result<Self, Error> {
         if ptr.is_null() {
             return Err(Error::WrapperError(String::from(
                 "try_from_ptr: pointer is null",
@@ -14,6 +15,46 @@ impl Model {
         }
 
         return Ok(Self { ptr });
+    }
+
+    pub fn name(&self) -> Result<&str, Error> {
+        let ret = unsafe { ffi::nn_model_name(self.ptr) };
+        if ret.is_null() {
+            return Err(Error::WrapperError(String::from("nn_model_name is null")));
+        }
+        let cstr = unsafe { CStr::from_ptr(ret) };
+        match cstr.to_str() {
+            Ok(s) => Ok(s),
+            Err(e) => Err(Error::WrapperError(e.to_string())),
+        }
+    }
+
+    /*
+    pub fn serial(&self) -> Result<&str, Error> {
+
+    }
+    */
+
+    pub fn label_count(&self) -> Result<i32, Error> {
+        let ret = unsafe { ffi::nn_model_label_count(self.ptr) };
+        if ret == 0 {
+            return Err(Error::WrapperError(String::from(
+                "No labels or model is invalid",
+            )));
+        }
+        Ok(ret)
+    }
+
+    pub fn label(&self, index: i32) -> Result<&str, Error> {
+        let ret = unsafe { ffi::nn_model_label(self.ptr, index) };
+        if ret.is_null() {
+            return Err(Error::WrapperError(String::from("label was NULL")));
+        }
+        let cstr = unsafe { CStr::from_ptr(ret) };
+        match cstr.to_str() {
+            Ok(s) => Ok(s),
+            Err(e) => Err(Error::WrapperError(e.to_string())),
+        }
     }
 
     pub fn inputs(&self) -> Result<&[u32], Error> {
@@ -25,7 +66,67 @@ impl Model {
                 "could not get model inputs",
             )));
         }
-
-        return Ok(unsafe { std::slice::from_raw_parts(ret, len) });
+        let outputs = unsafe { std::slice::from_raw_parts(ret, len) };
+        return Ok(outputs);
     }
+
+    pub fn outputs(&self) -> Result<&[u32], Error> {
+        let mut n_outputs: usize = 0;
+        let ret = unsafe { ffi::nn_model_outputs(self.ptr, &mut n_outputs as *mut usize) };
+        if ret.is_null() {
+            return Err(Error::WrapperError(String::from(
+                "could not get model outputs",
+            )));
+        }
+        let outputs = unsafe { std::slice::from_raw_parts(ret, n_outputs) };
+        return Ok(outputs);
+    }
+
+    pub fn layer_count(&self) -> usize {
+        return unsafe { ffi::nn_model_layer_count(self.ptr) };
+    }
+
+    pub fn layer_name(&self, index: usize) -> Result<&str, Error> {
+        let ret = unsafe { ffi::nn_model_layer_name(self.ptr, index) };
+        if ret.is_null() {
+            return Err(Error::WrapperError(String::from(
+                "nn_model_layer_name returned null",
+            )));
+        }
+        let cstr = unsafe { CStr::from_ptr(ret) };
+        match cstr.to_str() {
+            Ok(s) => Ok(s),
+            Err(e) => Err(Error::WrapperError(e.to_string())),
+        }
+    }
+
+    pub fn layer_lookup(&self, name: &str) -> Result<i32, Error> {
+        let name = match CString::new(name) {
+            Ok(s) => s,
+            Err(e) => return Err(Error::WrapperError(e.to_string())),
+        };
+
+        let ret = unsafe { ffi::nn_model_layer_lookup(self.ptr, name.into_raw()) };
+        if ret == -1 {
+            return Err(Error::WrapperError(String::from(
+                "Could not get index of layer",
+            )));
+        }
+        return Ok(ret);
+    }
+
+    /*
+    pub fn layer_type(&self, index: usize) -> Result<&str, Error> {
+        let ret = unsafe { ffi::nn_model_layer_type() };
+
+    }
+
+    pub fn layer_type_id(&self, index: usize) -> Result<i16, Error> {
+
+    }
+
+    pub fn layer_datatype(&self, index: usize) -> Result<> {
+
+    }
+    */
 }


### PR DESCRIPTION
- NNContext has been changed to Context
- Context now has an owned parameter. Additionally most functions no longer return deepviewrt-rs structs but instead references to those structs with the wrapped struct being held by the parent. (Context::tensor() is an exception)

This is a list of new functions 
Context
	sizeof
	new
	engine
	model
	load_model
	unload_model
	tensor
	tensor_index
	unsafe from_ptr
	drop

Engine
	to_ptr
	to_ptr_mut

Model
	name
	label_count
	label
	outputs
	layer_count
	layer_name
	layer_lookup
	
Tensor
	set_tensor_type
	engine
	dims
	axis
	zeros
	set_scales
	unmap is now unsafe 